### PR TITLE
Add support for incrementing by a value that is not a constant

### DIFF
--- a/src/FlexLabs.EntityFrameworkCore.Upsert/ExpressionHelpers.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/ExpressionHelpers.cs
@@ -28,8 +28,23 @@ namespace FlexLabs.EntityFrameworkCore.Upsert
                     }
 
                 case BinaryExpression exp:
-                    if (exp.Method == null && exp.Right is ConstantExpression constExp && exp.Left is MemberExpression memberExp && memberExp.Expression is ParameterExpression paramExp && memberExp.Member is PropertyInfo)
-                        return new KnownExpressions(paramExp.Type, memberExp.Member.Name, exp.NodeType, constExp.Value);
+                    if (exp.Method == null && exp.Left is MemberExpression leftOpMemberExp
+                                           && leftOpMemberExp.Expression is ParameterExpression paramExp
+                                           && leftOpMemberExp.Member is PropertyInfo)
+                    {
+                        switch (exp.Right)
+                        {
+                            case ConstantExpression constExp:
+                                return new KnownExpressions(paramExp.Type, leftOpMemberExp.Member.Name, exp.NodeType, constExp.Value);
+
+                            case MemberExpression rightOpMemberExp:
+                                return new KnownExpressions(paramExp.Type, leftOpMemberExp.Member.Name, exp.NodeType, rightOpMemberExp.GetValue());
+
+                            default:
+                                throw new Exception("can't handle this type of expression for the right operand: " + exp.Right.GetType());
+                        }
+                    }
+
                     if (exp.Method != null)
                         return exp.Method.Invoke(null, BindingFlags.Static | BindingFlags.Public, null, new[] { exp.Left.GetValue(), exp.Right.GetValue() }, CultureInfo.InvariantCulture);
 


### PR DESCRIPTION
I needed support for incrementing by a value that is only known at runtime, like this:

```csharp
public void IncrementIncomingResourceCount(int accountId, int resource, DateTime dateTime, int count)
{
    _dbContext
        .Upsert(
            new IncomingResourceCount
            {
                AccountId = accountId,
                Date = dateTime.Date,
                Hour = dateTime.Hour,
                Resource = resource,
                Count = count
            }
        )
        .On(c => new { c.AccountId, c.Date, c.Hour, c.Resource })
        .UpdateColumns(c => new IncomingResourceCount { Count = c.Count + count })
        .Run();
}
```

These changes seem to accomplish that.