### PR TITLE
CustomTypeConversions support

### DIFF
--- a/src/FlexLabs.EntityFrameworkCore.Upsert/FlexLabs.EntityFrameworkCore.Upsert.csproj
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/FlexLabs.EntityFrameworkCore.Upsert.csproj
@@ -33,7 +33,7 @@ Also supports injecting sql command generators to add support for other provider
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Release'">

--- a/src/FlexLabs.EntityFrameworkCore.Upsert/Internal/ConstantValue.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/Internal/ConstantValue.cs
@@ -1,4 +1,7 @@
-﻿namespace FlexLabs.EntityFrameworkCore.Upsert.Internal
+﻿using System.Reflection;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace FlexLabs.EntityFrameworkCore.Upsert.Internal
 {
     /// <summary>
     /// This class represents a constant value from an expression, which will be passed as a command argument
@@ -9,15 +12,29 @@
         /// Creates an instance of the ConstantValue class
         /// </summary>
         /// <param name="value">The value used in the expression</param>
-        public ConstantValue(object value)
+        /// <param name="property">The property from which the value is taken</param>
+        /// <param name="memberInfo">The memberInfo from which the value is taken</param>
+        public ConstantValue(object value, IProperty property = null, MemberInfo memberInfo = null)
         {
             Value = value;
+            Property = property;
+            MemberInfo = memberInfo;
         }
 
         /// <summary>
         /// The value used in the expression
         /// </summary>
         public object Value { get; }
+
+        /// <summary>
+        /// The property from which the value is taken
+        /// </summary>
+        public IProperty Property { get; }
+
+        /// <summary>
+        /// The memberInfo from which the value is taken
+        /// </summary>
+        public MemberInfo MemberInfo { get; }
 
         /// <summary>
         /// The index of the argument that will be passed to the Db command

--- a/src/FlexLabs.EntityFrameworkCore.Upsert/Internal/ExpressionHelpers.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/Internal/ExpressionHelpers.cs
@@ -94,10 +94,10 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Internal
                                                         switch (memberExp.Member)
                                                         {
                                                             case FieldInfo fInfo:
-                                                                return new ConstantValue(fInfo.GetValue(constExp.Value));
+                                                                return new ConstantValue(fInfo.GetValue(constExp.Value), property: null, memberInfo: fInfo);
 
                                                             case PropertyInfo pInfo:
-                                                                return new ConstantValue(pInfo.GetValue(constExp.Value));
+                                                                return new ConstantValue(pInfo.GetValue(constExp.Value), property: null, memberInfo: pInfo);
                                                         }
                                                         break;
                                                     }

--- a/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/RelationalUpsertCommandRunner.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/RelationalUpsertCommandRunner.cs
@@ -214,9 +214,9 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Runners
             var relationalTypeMappingSource = dbContext.GetService<IRelationalTypeMappingSource>();
             using (var dbCommand = dbContext.Database.GetDbConnection().CreateCommand())
             {
-                object PrepareCommandArgument(ConstantValue a) => PrepareDbCommandArgument(dbCommand, relationalTypeMappingSource, a);
                 var (sqlCommand, arguments) = PrepareCommand(entityType, entities, matchExpression, updateExpression, noUpdate);
-                dbContext.Database.ExecuteSqlCommand(sqlCommand, arguments.Select(PrepareCommandArgument));
+                var dbArguments = arguments.Select(a => PrepareDbCommandArgument(dbCommand, relationalTypeMappingSource, a));
+                dbContext.Database.ExecuteSqlCommand(sqlCommand, dbArguments);
             }
         }
 
@@ -227,9 +227,9 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Runners
             var relationalTypeMappingSource = dbContext.GetService<IRelationalTypeMappingSource>();
             using (var dbCommand = dbContext.Database.GetDbConnection().CreateCommand())
             {
-                object PrepareCommandArgument(ConstantValue a) => PrepareDbCommandArgument(dbCommand, relationalTypeMappingSource, a);
                 var (sqlCommand, arguments) = PrepareCommand(entityType, entities, matchExpression, updateExpression, noUpdate);
-                return dbContext.Database.ExecuteSqlCommandAsync(sqlCommand, arguments.Select(PrepareCommandArgument));
+                var dbArguments = arguments.Select(a => PrepareDbCommandArgument(dbCommand, relationalTypeMappingSource, a));
+                return dbContext.Database.ExecuteSqlCommandAsync(sqlCommand, dbArguments);
             }
         }
 

--- a/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/RelationalUpsertCommandRunner.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/RelationalUpsertCommandRunner.cs
@@ -1,12 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using FlexLabs.EntityFrameworkCore.Upsert.Internal;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace FlexLabs.EntityFrameworkCore.Upsert.Runners
 {
@@ -72,7 +76,7 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Runners
         /// </summary>
         protected virtual string TargetSuffix => null;
 
-        private (string SqlCommand, IEnumerable<object> Arguments) PrepareCommand<TEntity>(IEntityType entityType, ICollection<TEntity> entities,
+        private (string SqlCommand, IEnumerable<ConstantValue> Arguments) PrepareCommand<TEntity>(IEntityType entityType, ICollection<TEntity> entities,
             Expression<Func<TEntity, object>> match, Expression<Func<TEntity, TEntity, TEntity>> updater, bool noUpdate)
         {
             var joinColumns = ProcessMatchExpression(entityType, match);
@@ -97,7 +101,7 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Runners
 
                     var value = binding.Expression.GetValue<TEntity>(updater);
                     if (!(value is KnownExpression knownExp))
-                        knownExp = new KnownExpression(ExpressionType.Constant, new ConstantValue(value));
+                        knownExp = new KnownExpression(ExpressionType.Constant, new ConstantValue(value, property));
 
                     if (knownExp.Value1 is ParameterProperty epp1)
                         epp1.Property = entityType.FindProperty(epp1.PropertyName);
@@ -125,7 +129,7 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Runners
                     .Select(p =>
                     {
                         var columnName = p.Relational().ColumnName;
-                        var value = new ConstantValue(p.PropertyInfo.GetValue(e));
+                        var value = new ConstantValue(p.PropertyInfo.GetValue(e), p);
                         return (columnName, value);
                     })
                     .ToArray() as ICollection<(string ColumnName, ConstantValue Value)>)
@@ -140,7 +144,7 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Runners
 
             var columnUpdateExpressions = updateExpressions?.Select(x => (x.Property.Relational().ColumnName, x.Value)).ToArray();
             var sqlCommand = GenerateCommand(GetTableName(entityType), newEntities, joinColumnNames, columnUpdateExpressions);
-            return (sqlCommand, arguments.Select(a => a.Value));
+            return (sqlCommand, arguments);
         }
 
         private string ExpandValue(IKnownValue value)
@@ -207,16 +211,50 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Runners
         public override void Run<TEntity>(DbContext dbContext, IEntityType entityType, ICollection<TEntity> entities, Expression<Func<TEntity, object>> matchExpression,
             Expression<Func<TEntity, TEntity, TEntity>> updateExpression, bool noUpdate)
         {
-            var (sqlCommand, arguments) = PrepareCommand(entityType, entities, matchExpression, updateExpression, noUpdate);
-            dbContext.Database.ExecuteSqlCommand(sqlCommand, arguments);
+            var relationalTypeMappingSource = dbContext.GetService<IRelationalTypeMappingSource>();
+            using (var dbCommand = dbContext.Database.GetDbConnection().CreateCommand())
+            {
+                object PrepareCommandArgument(ConstantValue a) => PrepareDbCommandArgument(dbCommand, relationalTypeMappingSource, a);
+                var (sqlCommand, arguments) = PrepareCommand(entityType, entities, matchExpression, updateExpression, noUpdate);
+                dbContext.Database.ExecuteSqlCommand(sqlCommand, arguments.Select(PrepareCommandArgument));
+            }
         }
 
         /// <inheritdoc/>
         public override Task RunAsync<TEntity>(DbContext dbContext, IEntityType entityType, ICollection<TEntity> entities, Expression<Func<TEntity, object>> matchExpression,
             Expression<Func<TEntity, TEntity, TEntity>> updateExpression, bool noUpdate, CancellationToken cancellationToken)
         {
-            var (sqlCommand, arguments) = PrepareCommand(entityType, entities, matchExpression, updateExpression, noUpdate);
-            return dbContext.Database.ExecuteSqlCommandAsync(sqlCommand, arguments);
+            var relationalTypeMappingSource = dbContext.GetService<IRelationalTypeMappingSource>();
+            using (var dbCommand = dbContext.Database.GetDbConnection().CreateCommand())
+            {
+                object PrepareCommandArgument(ConstantValue a) => PrepareDbCommandArgument(dbCommand, relationalTypeMappingSource, a);
+                var (sqlCommand, arguments) = PrepareCommand(entityType, entities, matchExpression, updateExpression, noUpdate);
+                return dbContext.Database.ExecuteSqlCommandAsync(sqlCommand, arguments.Select(PrepareCommandArgument));
+            }
+        }
+
+        private object PrepareDbCommandArgument(DbCommand dbCommand, IRelationalTypeMappingSource relationalTypeMappingSource, ConstantValue constantValue)
+        {
+            RelationalTypeMapping relationalTypeMapping = null;
+
+            if (constantValue.Property != null)
+            {
+                relationalTypeMapping = relationalTypeMappingSource.FindMapping(constantValue.Property);
+            }
+            else if (constantValue.MemberInfo != null)
+            {
+                relationalTypeMapping = relationalTypeMappingSource.FindMapping(constantValue.MemberInfo);
+            }
+
+            var dbParameter = relationalTypeMapping?.CreateParameter(dbCommand, Parameter(constantValue.ArgumentIndex), constantValue.Value);
+            if (dbParameter == null)
+            {
+                dbParameter = dbCommand.CreateParameter();
+                dbParameter.Direction = ParameterDirection.Input;
+                dbParameter.Value = constantValue.Value;
+                dbParameter.ParameterName = Parameter(constantValue.ArgumentIndex);
+            }
+            return dbParameter;
         }
     }
 }

--- a/test/FlexLabs.EntityFrameworkCore.Upsert.Tests/EF/Base/Tables.cs
+++ b/test/FlexLabs.EntityFrameworkCore.Upsert.Tests/EF/Base/Tables.cs
@@ -33,6 +33,7 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Tests.EF.Base
 
     public class JsonData
     {
+        [Key, DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int ID { get; set; }
         public string Data { get; set; }
     }

--- a/test/FlexLabs.EntityFrameworkCore.Upsert.Tests/EF/Base/Tables.cs
+++ b/test/FlexLabs.EntityFrameworkCore.Upsert.Tests/EF/Base/Tables.cs
@@ -4,6 +4,13 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace FlexLabs.EntityFrameworkCore.Upsert.Tests.EF.Base
 {
+    public class Book
+    {
+        public int ID { get; set; }
+        public string Name { get; set; }
+        public string[] Genres { get; set; }
+    }
+
     public class Country
     {
         public int ID { get; set; }
@@ -13,6 +20,21 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Tests.EF.Base
         public string ISO { get; set; }
         public DateTime Created { get; set; }
         public DateTime Updated { get; set; }
+    }
+
+    [Table("Dash-Table")]
+    public class DashTable
+    {
+        public int ID { get; set; }
+        [Column("Data-Set")]
+        public string DataSet { get; set; }
+        public DateTime Updated { get; set; }
+    }
+
+    public class JsonData
+    {
+        public int ID { get; set; }
+        public string Data { get; set; }
     }
 
     public class PageVisit
@@ -25,23 +47,6 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Tests.EF.Base
         public DateTime LastVisit { get; set; }
     }
 
-    public class Status
-    {
-        [Key, DatabaseGenerated(DatabaseGeneratedOption.None)]
-        public int ID { get; set; }
-        public string Name { get; set; }
-        public DateTime LastChecked { get; set; }
-    }
-
-    [Table("Dash-Table")]
-    public class DashTable
-    {
-        public int ID { get; set; }
-        [Column("Data-Set")]
-        public string DataSet { get; set; }
-        public DateTime Updated { get; set; }
-    }
-
     [Table("SchemaTable", Schema = "testsch")]
     public class SchemaTable
     {
@@ -50,10 +55,11 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Tests.EF.Base
         public DateTime Updated { get; set; }
     }
 
-    public class Book
+    public class Status
     {
+        [Key, DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int ID { get; set; }
         public string Name { get; set; }
-        public string[] Genres { get; set; }
+        public DateTime LastChecked { get; set; }
     }
 }

--- a/test/FlexLabs.EntityFrameworkCore.Upsert.Tests/EF/Base/Tables.cs
+++ b/test/FlexLabs.EntityFrameworkCore.Upsert.Tests/EF/Base/Tables.cs
@@ -49,4 +49,11 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Tests.EF.Base
         public int Name { get; set; }
         public DateTime Updated { get; set; }
     }
+
+    public class Book
+    {
+        public int ID { get; set; }
+        public string Name { get; set; }
+        public string[] Genres { get; set; }
+    }
 }

--- a/test/FlexLabs.EntityFrameworkCore.Upsert.Tests/EF/Base/TestDbContext.cs
+++ b/test/FlexLabs.EntityFrameworkCore.Upsert.Tests/EF/Base/TestDbContext.cs
@@ -16,6 +16,9 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Tests.EF.Base
             modelBuilder.Entity<PageVisit>().HasIndex(pv => new { pv.UserID, pv.Date }).IsUnique();
             modelBuilder.Entity<DashTable>().HasIndex(t => t.DataSet).IsUnique();
             modelBuilder.Entity<SchemaTable>().HasIndex(t => t.Name).IsUnique();
+            modelBuilder.Entity<Book>().HasIndex(b => b.Name).IsUnique();
+            modelBuilder.Entity<Book>().Property(b => b.Genres)
+                .HasConversion(g => string.Join(",", g), s => s.Split(','));
         }
 
         public DbSet<Country> Countries { get; set; }
@@ -23,6 +26,7 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Tests.EF.Base
         public DbSet<Status> Statuses { get; set; }
         public DbSet<DashTable> DashTable { get; set; }
         public DbSet<SchemaTable> SchemaTable { get; set; }
+        public DbSet<Book> Books { get; set; }
 
         public enum DbDriver
         {

--- a/test/FlexLabs.EntityFrameworkCore.Upsert.Tests/EF/Base/TestDbContext.cs
+++ b/test/FlexLabs.EntityFrameworkCore.Upsert.Tests/EF/Base/TestDbContext.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.IO;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace FlexLabs.EntityFrameworkCore.Upsert.Tests.EF.Base
 {
@@ -12,21 +14,26 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Tests.EF.Base
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<Country>().HasIndex(c => c.ISO).IsUnique();
-            modelBuilder.Entity<PageVisit>().HasIndex(pv => new { pv.UserID, pv.Date }).IsUnique();
-            modelBuilder.Entity<DashTable>().HasIndex(t => t.DataSet).IsUnique();
-            modelBuilder.Entity<SchemaTable>().HasIndex(t => t.Name).IsUnique();
             modelBuilder.Entity<Book>().HasIndex(b => b.Name).IsUnique();
             modelBuilder.Entity<Book>().Property(b => b.Genres)
                 .HasConversion(g => string.Join(",", g), s => s.Split(','));
+            modelBuilder.Entity<Country>().HasIndex(c => c.ISO).IsUnique();
+            modelBuilder.Entity<DashTable>().HasIndex(t => t.DataSet).IsUnique();
+            modelBuilder.Entity<PageVisit>().HasIndex(pv => new { pv.UserID, pv.Date }).IsUnique();
+            modelBuilder.Entity<SchemaTable>().HasIndex(t => t.Name).IsUnique();
+
+            var dbProvider = this.GetService<IDatabaseProvider>();
+            if (dbProvider.Name == "Npgsql.EntityFrameworkCore.PostgreSQL")
+                modelBuilder.Entity<JsonData>().Property(j => j.Data).HasColumnType("jsonb");
         }
 
-        public DbSet<Country> Countries { get; set; }
-        public DbSet<PageVisit> PageVisits { get; set; }
-        public DbSet<Status> Statuses { get; set; }
-        public DbSet<DashTable> DashTable { get; set; }
-        public DbSet<SchemaTable> SchemaTable { get; set; }
         public DbSet<Book> Books { get; set; }
+        public DbSet<Country> Countries { get; set; }
+        public DbSet<DashTable> DashTable { get; set; }
+        public DbSet<JsonData> JsonDatas { get; set; }
+        public DbSet<PageVisit> PageVisits { get; set; }
+        public DbSet<SchemaTable> SchemaTable { get; set; }
+        public DbSet<Status> Statuses { get; set; }
 
         public enum DbDriver
         {


### PR DESCRIPTION
Fix for https://github.com/artiomchi/FlexLabs.Upsert/issues/8 and https://github.com/artiomchi/FlexLabs.Upsert/issues/9.
- ConstantValue can hold info about value's source property or member;
- RelationalUpsertCommandRunner wraps sqlCommand's arguments to DbParameters using IRelationalTypeMappingSource;
- Unit tests for new feature;