### PR TITLE
return affected rows for upsert

### DIFF
--- a/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/IUpsertCommandRunner.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/IUpsertCommandRunner.cs
@@ -31,7 +31,7 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Runners
         /// <param name="updateExpression">Expression that represents which properties will be updated, and what values will be set</param>
         /// <param name="noUpdate">Specifies that if a match is found, no action will be taken on the entity</param>
         /// <param name="useExpressionCompiler">If true, will fallback to the (slower) expression compiler for unhandled update expressions</param>
-        void Run<TEntity>(DbContext dbContext, IEntityType entityType, ICollection<TEntity> entities, Expression<Func<TEntity, object>> matchExpression,
+        int Run<TEntity>(DbContext dbContext, IEntityType entityType, ICollection<TEntity> entities, Expression<Func<TEntity, object>> matchExpression,
             Expression<Func<TEntity, TEntity, TEntity>> updateExpression, bool noUpdate, bool useExpressionCompiler) where TEntity : class;
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Runners
         /// <param name="useExpressionCompiler">If true, will fallback to the (slower) expression compiler for unhandled update expressions</param>
         /// <param name="cancellationToken">The CancellationToken to observe while waiting for the task to complete.</param>
         /// <returns>The task that represents the asynchronous upsert operation</returns>
-        Task RunAsync<TEntity>(DbContext dbContext, IEntityType entityType, ICollection<TEntity> entities, Expression<Func<TEntity, object>> matchExpression,
+        Task<int> RunAsync<TEntity>(DbContext dbContext, IEntityType entityType, ICollection<TEntity> entities, Expression<Func<TEntity, object>> matchExpression,
             Expression<Func<TEntity, TEntity, TEntity>> updateExpression, bool noUpdate, bool useExpressionCompiler, CancellationToken cancellationToken) where TEntity : class;
     }
 }

--- a/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/InMemoryUpsertCommandRunner.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/InMemoryUpsertCommandRunner.cs
@@ -94,15 +94,15 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Runners
         }
 
         /// <inheritdoc/>
-        public override void Run<TEntity>(DbContext dbContext, IEntityType entityType, ICollection<TEntity> entities, Expression<Func<TEntity, object>> matchExpression,
+        public override int Run<TEntity>(DbContext dbContext, IEntityType entityType, ICollection<TEntity> entities, Expression<Func<TEntity, object>> matchExpression,
             Expression<Func<TEntity, TEntity, TEntity>> updateExpression, bool noUpdate, bool useExpressionCompiler)
         {
             RunCore(dbContext, entityType, entities, matchExpression, updateExpression, noUpdate);
-            dbContext.SaveChanges();
+            return dbContext.SaveChanges();
         }
 
         /// <inheritdoc/>
-        public override Task RunAsync<TEntity>(DbContext dbContext, IEntityType entityType, ICollection<TEntity> entities, Expression<Func<TEntity, object>> matchExpression,
+        public override Task<int> RunAsync<TEntity>(DbContext dbContext, IEntityType entityType, ICollection<TEntity> entities, Expression<Func<TEntity, object>> matchExpression,
             Expression<Func<TEntity, TEntity, TEntity>> updateExpression, bool noUpdate, bool useExpressionCompiler, CancellationToken cancellationToken)
         {
             RunCore(dbContext, entityType, entities, matchExpression, updateExpression, noUpdate);

--- a/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/RelationalUpsertCommandRunner.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/RelationalUpsertCommandRunner.cs
@@ -223,7 +223,7 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Runners
         }
 
         /// <inheritdoc/>
-        public override void Run<TEntity>(DbContext dbContext, IEntityType entityType, ICollection<TEntity> entities, Expression<Func<TEntity, object>> matchExpression,
+        public override int Run<TEntity>(DbContext dbContext, IEntityType entityType, ICollection<TEntity> entities, Expression<Func<TEntity, object>> matchExpression,
             Expression<Func<TEntity, TEntity, TEntity>> updateExpression, bool noUpdate, bool useExpressionCompiler)
         {
             var relationalTypeMappingSource = dbContext.GetService<IRelationalTypeMappingSource>();
@@ -231,12 +231,12 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Runners
             {
                 var (sqlCommand, arguments) = PrepareCommand(entityType, entities, matchExpression, updateExpression, noUpdate, useExpressionCompiler);
                 var dbArguments = arguments.Select(a => PrepareDbCommandArgument(dbCommand, relationalTypeMappingSource, a));
-                dbContext.Database.ExecuteSqlCommand(sqlCommand, dbArguments);
+                return dbContext.Database.ExecuteSqlCommand(sqlCommand, dbArguments);
             }
         }
 
         /// <inheritdoc/>
-        public override Task RunAsync<TEntity>(DbContext dbContext, IEntityType entityType, ICollection<TEntity> entities, Expression<Func<TEntity, object>> matchExpression,
+        public override Task<int> RunAsync<TEntity>(DbContext dbContext, IEntityType entityType, ICollection<TEntity> entities, Expression<Func<TEntity, object>> matchExpression,
             Expression<Func<TEntity, TEntity, TEntity>> updateExpression, bool noUpdate, bool useExpressionCompiler, CancellationToken cancellationToken)
         {
             var relationalTypeMappingSource = dbContext.GetService<IRelationalTypeMappingSource>();

--- a/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/UpsertCommandRunnerBase.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/UpsertCommandRunnerBase.cs
@@ -19,11 +19,11 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Runners
         public abstract bool Supports(string name);
 
         /// <inheritdoc/>
-        public abstract void Run<TEntity>(DbContext dbContext, IEntityType entityType, ICollection<TEntity> entities, Expression<Func<TEntity, object>> matchExpression,
+        public abstract int Run<TEntity>(DbContext dbContext, IEntityType entityType, ICollection<TEntity> entities, Expression<Func<TEntity, object>> matchExpression,
             Expression<Func<TEntity, TEntity, TEntity>> updateExpression, bool noUpdate, bool useExpressionCompiler) where TEntity : class;
 
         /// <inheritdoc/>
-        public abstract Task RunAsync<TEntity>(DbContext dbContext, IEntityType entityType, ICollection<TEntity> entities, Expression<Func<TEntity, object>> matchExpression,
+        public abstract Task<int> RunAsync<TEntity>(DbContext dbContext, IEntityType entityType, ICollection<TEntity> entities, Expression<Func<TEntity, object>> matchExpression,
             Expression<Func<TEntity, TEntity, TEntity>> updateExpression, bool noUpdate, bool useExpressionCompiler, CancellationToken cancellationToken) where TEntity : class;
 
         /// <summary>


### PR DESCRIPTION
I made some changes to the signatures of Run/RunAsync on UpsertCommandBuilder. 

Instead of returning `void`, the value of affected rows is now returned, so that with the 'NoUpdate' provided to the command builder, we can know are there any rows successfully inserted into database by checking the returning value