### PR TITLE
Await execution of SqlCommand

### DIFF
--- a/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/RelationalUpsertCommandRunner.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/RelationalUpsertCommandRunner.cs
@@ -236,7 +236,7 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Runners
         }
 
         /// <inheritdoc/>
-        public override Task RunAsync<TEntity>(DbContext dbContext, IEntityType entityType, ICollection<TEntity> entities, Expression<Func<TEntity, object>> matchExpression,
+        public override async Task RunAsync<TEntity>(DbContext dbContext, IEntityType entityType, ICollection<TEntity> entities, Expression<Func<TEntity, object>> matchExpression,
             Expression<Func<TEntity, TEntity, TEntity>> updateExpression, bool noUpdate, bool useExpressionCompiler, CancellationToken cancellationToken)
         {
             var relationalTypeMappingSource = dbContext.GetService<IRelationalTypeMappingSource>();
@@ -244,7 +244,7 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Runners
             {
                 var (sqlCommand, arguments) = PrepareCommand(entityType, entities, matchExpression, updateExpression, noUpdate, useExpressionCompiler);
                 var dbArguments = arguments.Select(a => PrepareDbCommandArgument(dbCommand, relationalTypeMappingSource, a));
-                return dbContext.Database.ExecuteSqlCommandAsync(sqlCommand, dbArguments);
+                await dbContext.Database.ExecuteSqlCommandAsync(sqlCommand, dbArguments);
             }
         }
 


### PR DESCRIPTION
`dbCommand` could be disposed before the command had finished running. After this PR this should be fixed. 