### PR TITLE
Improve SqlServerUpsertCommandRunner to allow null values inside matchers

### DIFF
--- a/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/SqlServerUpsertCommandRunner.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/SqlServerUpsertCommandRunner.cs
@@ -29,7 +29,7 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Runners
             result.Append($") ) AS [S] (");
             result.Append(string.Join(", ", entities.First().Select(e => EscapeName(e.ColumnName))));
             result.Append(") ON ");
-            result.Append(string.Join(" AND ", joinColumns.Select(c => $"[T].[{c}] = [S].[{c}]")));
+            result.Append(string.Join(" AND ", joinColumns.Select(c => $"(([S].[{c}] IS NOT NULL AND [T].[{c}] = [S].[{c}]) OR ([S].[{c}] IS NULL AND [T].[{c}] IS NULL))")));
             result.Append(" WHEN NOT MATCHED BY TARGET THEN INSERT (");
             result.Append(string.Join(", ", entities.First().Select(e => EscapeName(e.ColumnName))));
             result.Append(") VALUES (");

--- a/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/SqlServerUpsertCommandRunner.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/SqlServerUpsertCommandRunner.cs
@@ -29,7 +29,7 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Runners
             result.Append($") ) AS [S] (");
             result.Append(string.Join(", ", entities.First().Select(e => EscapeName(e.ColumnName))));
             result.Append(") ON ");
-            result.Append(string.Join(" AND ", joinColumns.Select(c => $"(([S].[{c}] IS NOT NULL AND [T].[{c}] = [S].[{c}]) OR ([S].[{c}] IS NULL AND [T].[{c}] IS NULL))")));
+            result.Append(string.Join(" AND ", joinColumns.Select(c => $"(([S].[{c}] IS NULL AND [T].[{c}] IS NULL) OR ([S].[{c}] IS NOT NULL AND [T].[{c}] = [S].[{c}]))")));
             result.Append(" WHEN NOT MATCHED BY TARGET THEN INSERT (");
             result.Append(string.Join(", ", entities.First().Select(e => EscapeName(e.ColumnName))));
             result.Append(") VALUES (");

--- a/test/FlexLabs.EntityFrameworkCore.Upsert.Tests/Runners/SqlServerUpsertCommandRunnerTests.cs
+++ b/test/FlexLabs.EntityFrameworkCore.Upsert.Tests/Runners/SqlServerUpsertCommandRunnerTests.cs
@@ -9,41 +9,41 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Tests.Runners
         protected override string NoUpdate_Sql =>
             "MERGE INTO myTable WITH (HOLDLOCK) AS [T] " +
             "USING ( VALUES (@p0, @p1) ) AS [S] ([Name], [Status]) " +
-            "ON [T].[ID] = [S].[ID] " +
+            "ON (([S].[ID] IS NOT NULL AND [T].[ID] = [S].[ID]) OR ([S].[ID] IS NULL AND [T].[ID] IS NULL)) " +
             "WHEN NOT MATCHED BY TARGET THEN INSERT ([Name], [Status]) VALUES ([Name], [Status]);";
 
         protected override string Update_Constant_Sql =>
             "MERGE INTO myTable WITH (HOLDLOCK) AS [T] " +
             "USING ( VALUES (@p0, @p1) ) AS [S] ([Name], [Status]) " +
-            "ON [T].[ID] = [S].[ID] " +
+            "ON (([S].[ID] IS NOT NULL AND [T].[ID] = [S].[ID]) OR ([S].[ID] IS NULL AND [T].[ID] IS NULL)) " +
             "WHEN NOT MATCHED BY TARGET THEN INSERT ([Name], [Status]) VALUES ([Name], [Status]) " +
             "WHEN MATCHED THEN UPDATE SET [Name] = @p2;";
 
         protected override string Update_Source_Sql =>
             "MERGE INTO myTable WITH (HOLDLOCK) AS [T] " +
             "USING ( VALUES (@p0, @p1) ) AS [S] ([Name], [Status]) " +
-            "ON [T].[ID] = [S].[ID] " +
+            "ON (([S].[ID] IS NOT NULL AND [T].[ID] = [S].[ID]) OR ([S].[ID] IS NULL AND [T].[ID] IS NULL)) " +
             "WHEN NOT MATCHED BY TARGET THEN INSERT ([Name], [Status]) VALUES ([Name], [Status]) " +
             "WHEN MATCHED THEN UPDATE SET [Name] = [S].[Name];";
 
         protected override string Update_Source_RenamedCol_Sql =>
             "MERGE INTO myTable WITH (HOLDLOCK) AS [T] " +
             "USING ( VALUES (@p0, @p1) ) AS [S] ([Name], [Status]) " +
-            "ON [T].[ID] = [S].[ID] " +
+            "ON (([S].[ID] IS NOT NULL AND [T].[ID] = [S].[ID]) OR ([S].[ID] IS NULL AND [T].[ID] IS NULL)) " +
             "WHEN NOT MATCHED BY TARGET THEN INSERT ([Name], [Status]) VALUES ([Name], [Status]) " +
             "WHEN MATCHED THEN UPDATE SET [Name] = [S].[Name2];";
 
         protected override string Update_BinaryAdd_Sql =>
             "MERGE INTO myTable WITH (HOLDLOCK) AS [T] " +
             "USING ( VALUES (@p0, @p1) ) AS [S] ([Name], [Status]) " +
-            "ON [T].[ID] = [S].[ID] " +
+            "ON (([S].[ID] IS NOT NULL AND [T].[ID] = [S].[ID]) OR ([S].[ID] IS NULL AND [T].[ID] IS NULL)) " +
             "WHEN NOT MATCHED BY TARGET THEN INSERT ([Name], [Status]) VALUES ([Name], [Status]) " +
             "WHEN MATCHED THEN UPDATE SET [Status] = [T].[Status] + @p2;";
 
         protected override string Update_Coalesce_Sql =>
             "MERGE INTO myTable WITH (HOLDLOCK) AS [T] " +
             "USING ( VALUES (@p0, @p1) ) AS [S] ([Name], [Status]) " +
-            "ON [T].[ID] = [S].[ID] " +
+            "ON (([S].[ID] IS NOT NULL AND [T].[ID] = [S].[ID]) OR ([S].[ID] IS NULL AND [T].[ID] IS NULL)) " +
             "WHEN NOT MATCHED BY TARGET THEN INSERT ([Name], [Status]) VALUES ([Name], [Status]) " +
             "WHEN MATCHED THEN UPDATE SET [Status] = COALESCE([T].[Status], @p2);";
     }

--- a/test/FlexLabs.EntityFrameworkCore.Upsert.Tests/Runners/SqlServerUpsertCommandRunnerTests.cs
+++ b/test/FlexLabs.EntityFrameworkCore.Upsert.Tests/Runners/SqlServerUpsertCommandRunnerTests.cs
@@ -9,41 +9,41 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Tests.Runners
         protected override string NoUpdate_Sql =>
             "MERGE INTO myTable WITH (HOLDLOCK) AS [T] " +
             "USING ( VALUES (@p0, @p1) ) AS [S] ([Name], [Status]) " +
-            "ON (([S].[ID] IS NOT NULL AND [T].[ID] = [S].[ID]) OR ([S].[ID] IS NULL AND [T].[ID] IS NULL)) " +
+            "ON (([S].[ID] IS NULL AND [T].[ID] IS NULL) OR ([S].[ID] IS NOT NULL AND [T].[ID] = [S].[ID])) " +
             "WHEN NOT MATCHED BY TARGET THEN INSERT ([Name], [Status]) VALUES ([Name], [Status]);";
 
         protected override string Update_Constant_Sql =>
             "MERGE INTO myTable WITH (HOLDLOCK) AS [T] " +
             "USING ( VALUES (@p0, @p1) ) AS [S] ([Name], [Status]) " +
-            "ON (([S].[ID] IS NOT NULL AND [T].[ID] = [S].[ID]) OR ([S].[ID] IS NULL AND [T].[ID] IS NULL)) " +
+            "ON (([S].[ID] IS NULL AND [T].[ID] IS NULL) OR ([S].[ID] IS NOT NULL AND [T].[ID] = [S].[ID])) " +
             "WHEN NOT MATCHED BY TARGET THEN INSERT ([Name], [Status]) VALUES ([Name], [Status]) " +
             "WHEN MATCHED THEN UPDATE SET [Name] = @p2;";
 
         protected override string Update_Source_Sql =>
             "MERGE INTO myTable WITH (HOLDLOCK) AS [T] " +
             "USING ( VALUES (@p0, @p1) ) AS [S] ([Name], [Status]) " +
-            "ON (([S].[ID] IS NOT NULL AND [T].[ID] = [S].[ID]) OR ([S].[ID] IS NULL AND [T].[ID] IS NULL)) " +
+            "ON (([S].[ID] IS NULL AND [T].[ID] IS NULL) OR ([S].[ID] IS NOT NULL AND [T].[ID] = [S].[ID])) " +
             "WHEN NOT MATCHED BY TARGET THEN INSERT ([Name], [Status]) VALUES ([Name], [Status]) " +
             "WHEN MATCHED THEN UPDATE SET [Name] = [S].[Name];";
 
         protected override string Update_Source_RenamedCol_Sql =>
             "MERGE INTO myTable WITH (HOLDLOCK) AS [T] " +
             "USING ( VALUES (@p0, @p1) ) AS [S] ([Name], [Status]) " +
-            "ON (([S].[ID] IS NOT NULL AND [T].[ID] = [S].[ID]) OR ([S].[ID] IS NULL AND [T].[ID] IS NULL)) " +
+            "ON (([S].[ID] IS NULL AND [T].[ID] IS NULL) OR ([S].[ID] IS NOT NULL AND [T].[ID] = [S].[ID])) " +
             "WHEN NOT MATCHED BY TARGET THEN INSERT ([Name], [Status]) VALUES ([Name], [Status]) " +
             "WHEN MATCHED THEN UPDATE SET [Name] = [S].[Name2];";
 
         protected override string Update_BinaryAdd_Sql =>
             "MERGE INTO myTable WITH (HOLDLOCK) AS [T] " +
             "USING ( VALUES (@p0, @p1) ) AS [S] ([Name], [Status]) " +
-            "ON (([S].[ID] IS NOT NULL AND [T].[ID] = [S].[ID]) OR ([S].[ID] IS NULL AND [T].[ID] IS NULL)) " +
+            "ON (([S].[ID] IS NULL AND [T].[ID] IS NULL) OR ([S].[ID] IS NOT NULL AND [T].[ID] = [S].[ID])) " +
             "WHEN NOT MATCHED BY TARGET THEN INSERT ([Name], [Status]) VALUES ([Name], [Status]) " +
             "WHEN MATCHED THEN UPDATE SET [Status] = [T].[Status] + @p2;";
 
         protected override string Update_Coalesce_Sql =>
             "MERGE INTO myTable WITH (HOLDLOCK) AS [T] " +
             "USING ( VALUES (@p0, @p1) ) AS [S] ([Name], [Status]) " +
-            "ON (([S].[ID] IS NOT NULL AND [T].[ID] = [S].[ID]) OR ([S].[ID] IS NULL AND [T].[ID] IS NULL)) " +
+            "ON (([S].[ID] IS NULL AND [T].[ID] IS NULL) OR ([S].[ID] IS NOT NULL AND [T].[ID] = [S].[ID])) " +
             "WHEN NOT MATCHED BY TARGET THEN INSERT ([Name], [Status]) VALUES ([Name], [Status]) " +
             "WHEN MATCHED THEN UPDATE SET [Status] = COALESCE([T].[Status], @p2);";
     }


### PR DESCRIPTION
When using SQL Server for a database, null values being part of a matcher causes a duplicate key exception to be thrown since the matcher search condition is not properly checking for null values.

This pull request uses a more robust ON search condition to ensure that null can be checked properly.