### PR TITLE
Provide a useful error when TEntity not mapped in DbContext

### DIFF
--- a/src/FlexLabs.EntityFrameworkCore.Upsert/Resources.Designer.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/Resources.Designer.cs
@@ -106,6 +106,15 @@ namespace FlexLabs.EntityFrameworkCore.Upsert {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The TEntity type must be mapped in your DbContext..
+        /// </summary>
+        internal static string EntityTypeMustBeMappedInDbContext {
+            get {
+                return ResourceManager.GetString("EntityTypeMustBeMappedInDbContext", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Match columns have to be properties of the TEntity class.
         /// </summary>
         internal static string MatchColumnsHaveToBePropertiesOfTheTEntityClass {

--- a/src/FlexLabs.EntityFrameworkCore.Upsert/Resources.resx
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/Resources.resx
@@ -132,6 +132,9 @@
   <data name="DatabaseProviderNotSupportedYet" xml:space="preserve">
     <value>Database provider not supported yet!</value>
   </data>
+  <data name="EntityTypeMustBeMappedInDbContext" xml:space="preserve">
+    <value>The TEntity type must be mapped in your DbContext.</value>
+  </data>
   <data name="MatchColumnsHaveToBePropertiesOfTheTEntityClass" xml:space="preserve">
     <value>Match columns have to be properties of the TEntity class</value>
   </data>

--- a/src/FlexLabs.EntityFrameworkCore.Upsert/UpsertCommandBuilder.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/UpsertCommandBuilder.cs
@@ -39,6 +39,11 @@ namespace FlexLabs.EntityFrameworkCore.Upsert
             _entities = entities;
 
             _entityType = dbContext.GetService<IModel>().FindEntityType(typeof(TEntity));
+
+            if (_entityType == null)
+            {
+                throw new InvalidOperationException(Resources.EntityTypeMustBeMappedInDbContext);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
I made this silly mistake and almost dumped `FlexLabs.Upsert` when trying it the first time because I got a `NullReferenceException` deep down in the guts of the library.  It took me some time to realize it was really my mistake as I was introducing a new type of entity, but had not yet mapped it in my DbContext.

I apologize I do not have the correct version of the tooling for this library, so this PR is untested and likely contains bugs.  