### PR TITLE
allow reflected types

### DIFF
--- a/src/FlexLabs.EntityFrameworkCore.Upsert/UpsertCommandBuilder.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/UpsertCommandBuilder.cs
@@ -33,6 +33,25 @@ namespace FlexLabs.EntityFrameworkCore.Upsert
         /// </summary>
         /// <param name="dbContext">The data context that will be used to upsert entities</param>
         /// <param name="entities">The collection of entities to be upserted</param>
+        /// <param name="type">The anonymous type of the DbSet to be upserted</param>
+        internal UpsertCommandBuilder(DbContext dbContext, ICollection<TEntity> entities, Type type)
+        {
+            _dbContext = dbContext;
+            _entities = entities;
+
+            _entityType = dbContext.GetService<IModel>().FindEntityType(type);
+
+            if (_entityType == null)
+            {
+                throw new InvalidOperationException(Resources.EntityTypeMustBeMappedInDbContext);
+            }
+        }
+
+        /// <summary>
+        /// Initialise an instance of the UpsertCommandBuilder
+        /// </summary>
+        /// <param name="dbContext">The data context that will be used to upsert entities</param>
+        /// <param name="entities">The collection of entities to be upserted</param>
         internal UpsertCommandBuilder(DbContext dbContext, ICollection<TEntity> entities)
         {
             _dbContext = dbContext;
@@ -43,8 +62,7 @@ namespace FlexLabs.EntityFrameworkCore.Upsert
             if (_entityType == null)
             {
                 throw new InvalidOperationException(Resources.EntityTypeMustBeMappedInDbContext);
-            }
-        }
+            }        }
 
         /// <summary>
         /// Specifies which columns will be used to find matching entities between the collection passed and the ones stored in the database

--- a/src/FlexLabs.EntityFrameworkCore.Upsert/UpsertExtensions.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/UpsertExtensions.cs
@@ -27,7 +27,40 @@ namespace Microsoft.EntityFrameworkCore
             if (entity == null)
                 throw new ArgumentNullException(nameof(entity));
 
-            return UpsertRange(dbContext, entity);
+            return UpsertRange(dbContext, typeof(TEntity), entity);
+        }
+
+        /// <summary>
+        /// Attempt to insert an entity to the database, or update it if one already exists
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the entity being upserted</typeparam>
+        /// <param name="dbContext">The data context used to connect to the database</param>
+        /// <param name="type">The anonymous type of the DbSet to be upserted</param>
+        /// <param name="entity">The entity that is being upserted</param>
+        /// <returns>The upsert command builder that is used to configure and run the upsert operation</returns>
+        public static UpsertCommandBuilder<TEntity> Upsert<TEntity>(this DbContext dbContext, Type type, TEntity entity)
+            where TEntity : class
+        {
+            return UpsertRange(dbContext, type, entity);
+        }
+
+        /// <summary>
+        /// Attempt to insert an array of entities to the database, or update them if they already exist
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the entity being upserted</typeparam>
+        /// <param name="dbContext">The data context used to connect to the database</param>
+        /// <param name="type">The anonymous type of the DbSet to be upserted</param>
+        /// <param name="entities">The entities that are being upserted</param>
+        /// <returns>The upsert command builder that is used to configure and run the upsert operation</returns>
+        public static UpsertCommandBuilder<TEntity> UpsertRange<TEntity>(this DbContext dbContext, Type type, params TEntity[] entities)
+            where TEntity : class
+        {
+            if (dbContext == null)
+                throw new ArgumentNullException(nameof(dbContext));
+            if (entities == null)
+                throw new ArgumentNullException(nameof(entities));
+
+            return new UpsertCommandBuilder<TEntity>(dbContext, entities, type);
         }
 
         /// <summary>
@@ -40,12 +73,7 @@ namespace Microsoft.EntityFrameworkCore
         public static UpsertCommandBuilder<TEntity> UpsertRange<TEntity>(this DbContext dbContext, params TEntity[] entities)
             where TEntity : class
         {
-            if (dbContext == null)
-                throw new ArgumentNullException(nameof(dbContext));
-            if (entities == null)
-                throw new ArgumentNullException(nameof(entities));
-
-            return new UpsertCommandBuilder<TEntity>(dbContext, entities);
+            return UpsertRange(dbContext, typeof(TEntity), entities);
         }
 
         /// <summary>
@@ -53,9 +81,10 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <typeparam name="TEntity">The type of the entity being upserted</typeparam>
         /// <param name="dbContext">The data context used to connect to the database</param>
+        /// <param name="type">The anonymous type of the DbSet to be upserted</param>
         /// <param name="entities">The entities that are being upserted</param>
         /// <returns>The upsert command builder that is used to configure and run the upsert operation</returns>
-        public static UpsertCommandBuilder<TEntity> UpsertRange<TEntity>(this DbContext dbContext, IEnumerable<TEntity> entities)
+        public static UpsertCommandBuilder<TEntity> UpsertRange<TEntity>(this DbContext dbContext, Type type, IEnumerable<TEntity> entities)
             where TEntity : class
         {
             if (dbContext == null)
@@ -68,7 +97,20 @@ namespace Microsoft.EntityFrameworkCore
                 collection = entityCollection;
             else
                 collection = entities.ToArray();
-            return new UpsertCommandBuilder<TEntity>(dbContext, collection);
+            return new UpsertCommandBuilder<TEntity>(dbContext, collection, type);
+        }
+
+        /// <summary>
+        /// Attempt to insert an array of entities to the database, or update them if they already exist
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the entity being upserted</typeparam>
+        /// <param name="dbContext">The data context used to connect to the database</param>
+        /// <param name="entities">The entities that are being upserted</param>
+        /// <returns>The upsert command builder that is used to configure and run the upsert operation</returns>
+        public static UpsertCommandBuilder<TEntity> UpsertRange<TEntity>(this DbContext dbContext, IEnumerable<TEntity> entities)
+            where TEntity : class
+        {
+            return UpsertRange(dbContext, typeof(TEntity), entities);
         }
 
         /// <summary>
@@ -81,13 +123,27 @@ namespace Microsoft.EntityFrameworkCore
         public static UpsertCommandBuilder<TEntity> Upsert<TEntity>(this DbSet<TEntity> dbSet, TEntity entity)
             where TEntity : class
         {
+            return Upsert(dbSet, typeof(TEntity), entity);
+        }
+
+        /// <summary>
+        /// Attempt to insert an entity to the database, or update it if one already exists
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the entity being upserted</typeparam>
+        /// <param name="dbSet">The db set where the item will be upserted</param>
+        /// <param name="type">The anonymous type of the DbSet to be upserted</param>
+        /// <param name="entity">The entity that is being upserted</param>
+        /// <returns>The upsert command builder that is used to configure and run the upsert operation</returns>
+        public static UpsertCommandBuilder<TEntity> Upsert<TEntity>(this DbSet<TEntity> dbSet, Type type, TEntity entity)
+            where TEntity : class
+        {
             if (dbSet == null)
                 throw new ArgumentNullException(nameof(dbSet));
             if (entity == null)
                 throw new ArgumentNullException(nameof(entity));
 
             var dbContext = dbSet.GetService<ICurrentDbContext>().Context;
-            return Upsert(dbContext, entity);
+            return Upsert(dbContext, type, entity);
         }
 
         /// <summary>
@@ -100,13 +156,7 @@ namespace Microsoft.EntityFrameworkCore
         public static UpsertCommandBuilder<TEntity> UpsertRange<TEntity>(this DbSet<TEntity> dbSet, params TEntity[] entities)
             where TEntity : class
         {
-            if (dbSet == null)
-                throw new ArgumentNullException(nameof(dbSet));
-            if (entities == null)
-                throw new ArgumentNullException(nameof(entities));
-
-            var dbContext = dbSet.GetService<ICurrentDbContext>().Context;
-            return UpsertRange(dbContext, entities);
+            return UpsertRange(dbSet, typeof(TEntity), entities);
         }
 
         /// <summary>
@@ -119,13 +169,47 @@ namespace Microsoft.EntityFrameworkCore
         public static UpsertCommandBuilder<TEntity> UpsertRange<TEntity>(this DbSet<TEntity> dbSet, IEnumerable<TEntity> entities)
             where TEntity : class
         {
+            return UpsertRange(dbSet, typeof(TEntity), entities);
+        }
+
+        /// <summary>
+        /// Attempt to insert an array of entities to the database, or update them if they already exist
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the entity being upserted</typeparam>
+        /// <param name="dbSet">The db set where the items will be upserted</param>
+        /// <param name="type">The anonymous type of the DbSet to be upserted</param>
+        /// <param name="entities">The entities that are being upserted</param>
+        /// <returns>The upsert command builder that is used to configure and run the upsert operation</returns>
+        public static UpsertCommandBuilder<TEntity> UpsertRange<TEntity>(this DbSet<TEntity> dbSet, Type type, params TEntity[] entities)
+            where TEntity : class
+        {
             if (dbSet == null)
                 throw new ArgumentNullException(nameof(dbSet));
             if (entities == null)
                 throw new ArgumentNullException(nameof(entities));
 
             var dbContext = dbSet.GetService<ICurrentDbContext>().Context;
-            return UpsertRange(dbContext, entities);
+            return UpsertRange(dbContext, type, entities);
+        }
+
+        /// <summary>
+        /// Attempt to insert an array of entities to the database, or update them if they already exist
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the entity being upserted</typeparam>
+        /// <param name="dbSet">The db set where the items will be upserted</param>
+        /// <param name="type">The anonymous type of the DbSet to be upserted</param>
+        /// <param name="entities">The entities that are being upserted</param>
+        /// <returns>The upsert command builder that is used to configure and run the upsert operation</returns>
+        public static UpsertCommandBuilder<TEntity> UpsertRange<TEntity>(this DbSet<TEntity> dbSet, Type type, IEnumerable<TEntity> entities)
+            where TEntity : class
+        {
+            if (dbSet == null)
+                throw new ArgumentNullException(nameof(dbSet));
+            if (entities == null)
+                throw new ArgumentNullException(nameof(entities));
+
+            var dbContext = dbSet.GetService<ICurrentDbContext>().Context;
+            return UpsertRange(dbContext, type, entities);
         }
     }
 }


### PR DESCRIPTION
Should be self-explanatory. This allows, for instance, the ability to loop through all entities that match a particular interface, if you know the anonymous type. At present the generic type will be assumed to be the interface, and not be found among the DbSets.