### PR TITLE
Bugfix to enable constants in UpdateIf expressions

### DIFF
--- a/src/FlexLabs.EntityFrameworkCore.Upsert/FlexLabs.EntityFrameworkCore.Upsert.csproj
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/FlexLabs.EntityFrameworkCore.Upsert.csproj
@@ -43,10 +43,12 @@ v2.2.0:
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <!--
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\certs\FlexLabsStrongKey.snk</AssemblyOriginatorKeyFile>
     <SignCertificateName>Artiom Chilaru</SignCertificateName>
     <PostBuildEvent>signtool.exe sign /n "$(SignCertificateName)" /fd sha256 /tr "http://timestamp.digicert.com" /td sha256 FlexLabs.EntityFrameworkCore.Upsert.dll</PostBuildEvent>
+    -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FlexLabs.EntityFrameworkCore.Upsert/FlexLabs.EntityFrameworkCore.Upsert.csproj
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/FlexLabs.EntityFrameworkCore.Upsert.csproj
@@ -50,11 +50,11 @@ v2.2.0:
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Release'">

--- a/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/RelationalUpsertCommandRunner.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/RelationalUpsertCommandRunner.cs
@@ -173,7 +173,7 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Runners
                     arguments.AddRange(updateExpressions.SelectMany(e => e.Value.GetConstantValues()));
 
                 if(updateConditionExpression != null)
-                    arguments.AddRange(updateConditionExpression.GetConstantValues());
+                    arguments.AddRange(updateConditionExpression.GetConstantValues().Where(c => c.Value != null));
 
                 var entitiesHere = 0;
                 do

--- a/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/RelationalUpsertCommandRunner.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/RelationalUpsertCommandRunner.cs
@@ -172,6 +172,9 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Runners
                 if (updateExpressions != null)
                     arguments.AddRange(updateExpressions.SelectMany(e => e.Value.GetConstantValues()));
 
+                if(updateConditionExpression != null)
+                    arguments.AddRange(updateConditionExpression.GetConstantValues());
+
                 var entitiesHere = 0;
                 do
                 {


### PR DESCRIPTION
This PR fixes an issue where it was not possible to use constants in the WHERE clause in the UpdateIf() logic.

Prior to this fix, this logic would not work correctly:

await _db.MyEntities.UpsertRange(data)
                    .UpdateIf((existingRow, newRow) => newRow.IsBool == true)
                    .RunAsync(ct);

It should also fix the issue raised with DateTime, but I haven't tested that: 
https://github.com/artiomchi/FlexLabs.Upsert/issues/56
