### PR TITLE
Correct Run result.

### DIFF
--- a/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/RelationalUpsertCommandRunner.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/RelationalUpsertCommandRunner.cs
@@ -361,7 +361,7 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Runners
             {
                 using var dbCommand = dbContext.Database.GetDbConnection().CreateCommand();
                 var dbArguments = arguments.Select(a => PrepareDbCommandArgument(dbCommand, relationalTypeMappingSource, a));
-                result = dbContext.Database.ExecuteSqlRaw(sqlCommand, dbArguments);
+                result += dbContext.Database.ExecuteSqlRaw(sqlCommand, dbArguments);
             }
             return result;
         }
@@ -384,7 +384,7 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Runners
             {
                 using var dbCommand = dbContext.Database.GetDbConnection().CreateCommand();
                 var dbArguments = arguments.Select(a => PrepareDbCommandArgument(dbCommand, relationalTypeMappingSource, a));
-                result = await dbContext.Database.ExecuteSqlRawAsync(sqlCommand, dbArguments).ConfigureAwait(false);
+                result += await dbContext.Database.ExecuteSqlRawAsync(sqlCommand, dbArguments).ConfigureAwait(false);
             }
             return result;
         }


### PR DESCRIPTION
According to the [Documentation](https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.relationaldatabasefacadeextensions.executesqlraw?view=efcore-3.1#Microsoft_EntityFrameworkCore_RelationalDatabaseFacadeExtensions_ExecuteSqlRaw_Microsoft_EntityFrameworkCore_Infrastructure_DatabaseFacade_System_String_System_Object___), the return value of the `ExecuteSqlRaw` call is the number fo the rows affected. The current implementation returns the value of the last batch. I believe that the correct behavior is to return a sum across all batches that get run.