### PR TITLE
Use DBSet.EntityType when possible

### DIFF
--- a/src/FlexLabs.EntityFrameworkCore.Upsert/UpsertCommandBuilder.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/UpsertCommandBuilder.cs
@@ -32,14 +32,13 @@ namespace FlexLabs.EntityFrameworkCore.Upsert
         /// Initialise an instance of the UpsertCommandBuilder
         /// </summary>
         /// <param name="dbContext">The data context that will be used to upsert entities</param>
+        /// <param name="entityType">The entity type for the entities to be upserted</param>
         /// <param name="entities">The collection of entities to be upserted</param>
-        internal UpsertCommandBuilder(DbContext dbContext, ICollection<TEntity> entities)
+        internal UpsertCommandBuilder(DbContext dbContext, IEntityType entityType, ICollection<TEntity> entities)
         {
             _dbContext = dbContext;
+            _entityType = entityType;
             _entities = entities;
-
-            _entityType = dbContext.GetService<IModel>().FindEntityType(typeof(TEntity))
-                ?? throw new InvalidOperationException(Resources.EntityTypeMustBeMappedInDbContext);
         }
 
         /// <summary>

--- a/src/FlexLabs.EntityFrameworkCore.Upsert/UpsertExtensions.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/UpsertExtensions.cs
@@ -4,7 +4,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using FlexLabs.EntityFrameworkCore.Upsert;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace Microsoft.EntityFrameworkCore

--- a/src/FlexLabs.EntityFrameworkCore.Upsert/UpsertExtensions.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/UpsertExtensions.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using FlexLabs.EntityFrameworkCore.Upsert;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -47,7 +48,10 @@ namespace Microsoft.EntityFrameworkCore
             if (entities == null)
                 throw new ArgumentNullException(nameof(entities));
 
-            return new UpsertCommandBuilder<TEntity>(dbContext, entities);
+            var entityType = dbContext.GetService<IModel>().FindEntityType(typeof(TEntity))
+                ?? throw new InvalidOperationException(Resources.EntityTypeMustBeMappedInDbContext);
+
+            return new UpsertCommandBuilder<TEntity>(dbContext, entityType, entities);
         }
 
         /// <summary>
@@ -65,12 +69,16 @@ namespace Microsoft.EntityFrameworkCore
             if (entities == null)
                 throw new ArgumentNullException(nameof(entities));
 
+            var entityType = dbContext.GetService<IModel>().FindEntityType(typeof(TEntity))
+                ?? throw new InvalidOperationException(Resources.EntityTypeMustBeMappedInDbContext);
+
             ICollection<TEntity> collection;
             if (entities is ICollection<TEntity> entityCollection)
                 collection = entityCollection;
             else
                 collection = entities.ToArray();
-            return new UpsertCommandBuilder<TEntity>(dbContext, collection);
+
+            return new UpsertCommandBuilder<TEntity>(dbContext, entityType, collection);
         }
 
         /// <summary>
@@ -88,8 +96,7 @@ namespace Microsoft.EntityFrameworkCore
             if (entity == null)
                 throw new ArgumentNullException(nameof(entity));
 
-            var dbContext = dbSet.GetService<ICurrentDbContext>().Context;
-            return Upsert(dbContext, entity);
+            return UpsertRange(dbSet, entity);
         }
 
         /// <summary>
@@ -109,7 +116,9 @@ namespace Microsoft.EntityFrameworkCore
                 throw new ArgumentNullException(nameof(entities));
 
             var dbContext = dbSet.GetService<ICurrentDbContext>().Context;
-            return UpsertRange(dbContext, entities);
+            var entityType = dbSet.EntityType;
+
+            return new UpsertCommandBuilder<TEntity>(dbContext, entityType, entities);
         }
 
         /// <summary>
@@ -128,7 +137,15 @@ namespace Microsoft.EntityFrameworkCore
                 throw new ArgumentNullException(nameof(entities));
 
             var dbContext = dbSet.GetService<ICurrentDbContext>().Context;
-            return UpsertRange(dbContext, entities);
+            var entityType = dbSet.EntityType;
+
+            ICollection<TEntity> collection;
+            if (entities is ICollection<TEntity> entityCollection)
+                collection = entityCollection;
+            else
+                collection = entities.ToArray();
+
+            return new UpsertCommandBuilder<TEntity>(dbContext, entityType, collection);
         }
     }
 }

--- a/src/FlexLabs.EntityFrameworkCore.Upsert/UpsertExtensions.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/UpsertExtensions.cs
@@ -49,7 +49,6 @@ namespace Microsoft.EntityFrameworkCore
 
             var entityType = dbContext.GetService<IModel>().FindEntityType(typeof(TEntity))
                 ?? throw new InvalidOperationException(Resources.EntityTypeMustBeMappedInDbContext);
-
             return new UpsertCommandBuilder<TEntity>(dbContext, entityType, entities);
         }
 
@@ -70,13 +69,11 @@ namespace Microsoft.EntityFrameworkCore
 
             var entityType = dbContext.GetService<IModel>().FindEntityType(typeof(TEntity))
                 ?? throw new InvalidOperationException(Resources.EntityTypeMustBeMappedInDbContext);
-
-            ICollection<TEntity> collection;
-            if (entities is ICollection<TEntity> entityCollection)
-                collection = entityCollection;
-            else
-                collection = entities.ToArray();
-
+            var collection = entities switch
+            {
+                ICollection<TEntity> entityCollection => entityCollection,
+                _ => entities.ToArray()
+            };
             return new UpsertCommandBuilder<TEntity>(dbContext, entityType, collection);
         }
 
@@ -115,9 +112,7 @@ namespace Microsoft.EntityFrameworkCore
                 throw new ArgumentNullException(nameof(entities));
 
             var dbContext = dbSet.GetService<ICurrentDbContext>().Context;
-            var entityType = dbSet.EntityType;
-
-            return new UpsertCommandBuilder<TEntity>(dbContext, entityType, entities);
+            return new UpsertCommandBuilder<TEntity>(dbContext, dbSet.EntityType, entities);
         }
 
         /// <summary>
@@ -136,15 +131,12 @@ namespace Microsoft.EntityFrameworkCore
                 throw new ArgumentNullException(nameof(entities));
 
             var dbContext = dbSet.GetService<ICurrentDbContext>().Context;
-            var entityType = dbSet.EntityType;
-
-            ICollection<TEntity> collection;
-            if (entities is ICollection<TEntity> entityCollection)
-                collection = entityCollection;
-            else
-                collection = entities.ToArray();
-
-            return new UpsertCommandBuilder<TEntity>(dbContext, entityType, collection);
+            var collection = entities switch
+            {
+                ICollection<TEntity> entityCollection => entityCollection,
+                _ => entities.ToArray()
+            };
+            return new UpsertCommandBuilder<TEntity>(dbContext, dbSet.EntityType, collection);
         }
     }
 }


### PR DESCRIPTION
When using shared-type entity types, `FindEntityType()` returns `null` even though the entity type exists. This made it impossible to use the library in combination with any of these.

Fortunately, when a DBSet is provided, we can access the entity type directly instead of having to find it on the context.

Let me know if you'd like more factorization to avoid some of the duplicated code.