### PR TITLE
Adds .NET 8 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,7 @@ jobs:
     steps:
     - uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          8.0.x
-          9.0.x
+        dotnet-version: 9.0.x
     - uses: actions/checkout@v4
     - name: Enable Postgres
       run: sc config postgresql-x64-17 start= demand
@@ -47,7 +45,7 @@ jobs:
     - name: Test
       env:
         FLEXLABS_UPSERT_TESTS_POSTGRESQL_CONNECTION_STRING: 'Server=localhost;Port=5432;Database=testuser;Username=postgres;Password=root'
-      run: dotnet test ./test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests --no-build --logger "trx;LogFileName=test-results.trx"
+      run: dotnet test ./test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests --no-build -f net9.0 --logger "trx;LogFileName=test-results.trx"
     - name: Test Report
       uses: actions/upload-artifact@v4
       if: success() || failure()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,9 @@ jobs:
     steps:
     - uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0'
+        dotnet-version: |
+          8.0.x
+          9.0.x
     - uses: actions/checkout@v4
     - name: Restore dependencies
       run: dotnet restore
@@ -30,7 +32,9 @@ jobs:
     steps:
     - uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0'
+        dotnet-version: |
+          8.0.x
+          9.0.x
     - uses: actions/checkout@v4
     - name: Enable Postgres
       run: sc config postgresql-x64-14 start= demand

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,9 +37,9 @@ jobs:
           9.0.x
     - uses: actions/checkout@v4
     - name: Enable Postgres
-      run: sc config postgresql-x64-14 start= demand
+      run: sc config postgresql-x64-17 start= demand
     - name: Start Postgres
-      run: net start postgresql-x64-14
+      run: net start postgresql-x64-17
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/src/FlexLabs.EntityFrameworkCore.Upsert/FlexLabs.EntityFrameworkCore.Upsert.csproj
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/FlexLabs.EntityFrameworkCore.Upsert.csproj
@@ -3,7 +3,7 @@
   <Sdk Name="DotNet.ReproducibleBuilds.Isolated" Version="$(ReproducibleBuildsVersion)" />
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Nullable>enable</Nullable>

--- a/src/FlexLabs.EntityFrameworkCore.Upsert/FlexLabs.EntityFrameworkCore.Upsert.csproj
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/FlexLabs.EntityFrameworkCore.Upsert.csproj
@@ -23,7 +23,7 @@ Also supports injecting sql command generators to add support for other provider
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>Entity Framework Core entity-framework-core EF EntityFramework EntityFrameworkCore EFCore Upsert</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <VersionPrefix>9.100.0</VersionPrefix>
+    <VersionPrefix>9.100.1</VersionPrefix>
     <PackageReleaseNotes>
 v9.100.0
 + Significant internal upgrade with a new expression parser (Thanks to @r-Larch)

--- a/test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests/ContainerisedDatabaseInitializerFixture.cs
+++ b/test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests/ContainerisedDatabaseInitializerFixture.cs
@@ -17,7 +17,7 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests
 
         protected static TBuilder ConfigureContainer(TBuilder builder)
             => builder
-                .WithName($"flexlabs_upsert_{DbDriverName.ToLowerInvariant()}")
+                .WithName($"flexlabs_upsert_{DbDriverName.ToLowerInvariant()}_{Environment.Version}")
                 .WithReuse(true);
 
         protected string ConnectionString

--- a/test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests/ContainerisedDatabaseInitializerFixture.cs
+++ b/test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests/ContainerisedDatabaseInitializerFixture.cs
@@ -17,7 +17,7 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests
 
         protected static TBuilder ConfigureContainer(TBuilder builder)
             => builder
-                .WithName($"flexlabs_upsert_{DbDriverName.ToLowerInvariant()}_{Environment.Version}")
+                .WithName($"flexlabs_upsert_{DbDriverName.ToLowerInvariant()}_net{Environment.Version.Major}")
                 .WithReuse(true);
 
         protected string ConnectionString

--- a/test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests.csproj
+++ b/test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
     <NoWarn>EF1001</NoWarn>

--- a/test/FlexLabs.EntityFrameworkCore.Upsert.Tests/FlexLabs.EntityFrameworkCore.Upsert.Tests.csproj
+++ b/test/FlexLabs.EntityFrameworkCore.Upsert.Tests/FlexLabs.EntityFrameworkCore.Upsert.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
     <NoWarn>EF1001</NoWarn>


### PR DESCRIPTION
Adds support for the .NET 8 target framework to the project.

This change enables the library and tests to be built and run against .NET 8, while maintaining compatibility with .NET 9. This ensures that users can utilize the library in their .NET 8 projects and benefit from the latest features and improvements. EFCore 9 targets .NET 8

The changes include:
- Updating the target frameworks in the project files to include `net8.0`.
- Modifying the build workflow to install both .NET 8 and .NET 9 SDKs.
<img width="1788" height="1384" alt="image" src="https://github.com/user-attachments/assets/d1df42c7-4373-4b2d-a48a-d219b186fbba" />
