### PR TITLE
Use mssql/server:2025-latest instead of mssql/rhel/server:2025-latest

### DIFF
--- a/test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests/DbTests_SqlServer.cs
+++ b/test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests/DbTests_SqlServer.cs
@@ -23,9 +23,9 @@ public class DbTests_SqlServer(DbTests_SqlServer.DatabaseInitializer contexts) :
             public override DbProviderFactory DbProviderFactory
                 => SqlClientFactory.Instance;
 
-            // https://mcr.microsoft.com/en-us/artifact/mar/mssql/rhel/server/tags
+            // https://mcr.microsoft.com/en-us/artifact/mar/mssql/server/tags
             protected override MsSqlBuilder Configure()
-                => ConfigureContainer(new MsSqlBuilder("mcr.microsoft.com/mssql/rhel/server:2025-latest"));
+                => ConfigureContainer(new MsSqlBuilder("mcr.microsoft.com/mssql/server:2025-latest"));
         }
     }
 }


### PR DESCRIPTION
The RHEL based container doesn't start on Apple Silicon Macs. It fails with this error.
> Fatal glibc error: CPU does not support x86-64-v3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains no user-facing changes. Updates were made exclusively to internal test infrastructure and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->