### PR TITLE
Use the dbContext `Model` property instead of GetService<IModel>()

### DIFF
--- a/src/FlexLabs.EntityFrameworkCore.Upsert/UpsertExtensions.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/UpsertExtensions.cs
@@ -40,7 +40,7 @@ public static class UpsertExtensions
         ArgumentNullException.ThrowIfNull(entities);
 
         var entityType = dbContext.Model.FindEntityType(typeof(TEntity))
-            ?? (entities.Length == 0 ? null : dbContext.Model.FindEntityType(entities.First().GetType()))
+            ?? (entities.Length > 0 ? dbContext.Model.FindEntityType(entities.First().GetType()) : null)
             ?? throw new InvalidOperationException(Resources.EntityTypeMustBeMappedInDbContext);
         return new UpsertCommandBuilder<TEntity>(dbContext, entityType, entities);
     }
@@ -64,7 +64,7 @@ public static class UpsertExtensions
             _ => entities.ToArray()
         };
         var entityType = dbContext.Model.FindEntityType(typeof(TEntity))
-            ?? (collection.Count > 0 ? null : dbContext.Model.FindEntityType(collection.First().GetType()))
+            ?? (collection.Count > 0 ? dbContext.Model.FindEntityType(collection.First().GetType()) : null)
             ?? throw new InvalidOperationException(Resources.EntityTypeMustBeMappedInDbContext);
         return new UpsertCommandBuilder<TEntity>(dbContext, entityType, collection);
     }

--- a/src/FlexLabs.EntityFrameworkCore.Upsert/UpsertExtensions.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/UpsertExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using FlexLabs.EntityFrameworkCore.Upsert;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace Microsoft.EntityFrameworkCore;
 
@@ -40,8 +39,8 @@ public static class UpsertExtensions
         ArgumentNullException.ThrowIfNull(dbContext);
         ArgumentNullException.ThrowIfNull(entities);
 
-        var entityType = dbContext.GetService<IModel>().FindEntityType(typeof(TEntity))
-            ?? (entities.Length == 0 ? null : dbContext.GetService<IModel>().FindEntityType(entities.First().GetType()))
+        var entityType = dbContext.Model.FindEntityType(typeof(TEntity))
+            ?? (entities.Length == 0 ? null : dbContext.Model.FindEntityType(entities.First().GetType()))
             ?? throw new InvalidOperationException(Resources.EntityTypeMustBeMappedInDbContext);
         return new UpsertCommandBuilder<TEntity>(dbContext, entityType, entities);
     }
@@ -64,8 +63,8 @@ public static class UpsertExtensions
             ICollection<TEntity> entityCollection => entityCollection,
             _ => entities.ToArray()
         };
-        var entityType = dbContext.GetService<IModel>().FindEntityType(typeof(TEntity))
-            ?? (collection.Count > 0 ? null : dbContext.GetService<IModel>().FindEntityType(collection.First().GetType()))
+        var entityType = dbContext.Model.FindEntityType(typeof(TEntity))
+            ?? (collection.Count > 0 ? null : dbContext.Model.FindEntityType(collection.First().GetType()))
             ?? throw new InvalidOperationException(Resources.EntityTypeMustBeMappedInDbContext);
         return new UpsertCommandBuilder<TEntity>(dbContext, entityType, collection);
     }

--- a/test/FlexLabs.EntityFrameworkCore.Upsert.Tests/Runners/RelationalCommandRunnerTestsBase.cs
+++ b/test/FlexLabs.EntityFrameworkCore.Upsert.Tests/Runners/RelationalCommandRunnerTestsBase.cs
@@ -43,6 +43,7 @@ public abstract class RelationalCommandRunnerTestsBase<TRunner>
         serviceProvider.GetRequiredService<IModelRuntimeInitializer>().Initialize(_model);
 
         _dbContext = Substitute.For<DbContext, IInfrastructure<IServiceProvider>>();
+        _dbContext.Model.Returns(_model);
         ((IInfrastructure<IServiceProvider>)_dbContext).Instance.Returns(serviceProvider);
 
         var relationalConnection = Substitute.For<IRelationalConnection>();


### PR DESCRIPTION
It's just simpler to use the dedicated `Model` property rather than going through `GetService<IModel>()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved entity metadata handling for upsert operations, increasing reliability when determining entity mappings.
* **Tests**
  * Enhanced test infrastructure to ensure the data model is accessible during upsert execution, improving test accuracy and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->