### PR TITLE
fix: Allow nullable Exclude properties

### DIFF
--- a/src/FlexLabs.EntityFrameworkCore.Upsert/UpsertCommandBuilder.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/UpsertCommandBuilder.cs
@@ -18,7 +18,7 @@ public class UpsertCommandBuilder<TEntity> where TEntity : class
     private readonly IEntityType _entityType;
     private readonly ICollection<TEntity> _entities;
     private Expression<Func<TEntity, object>>? _matchExpression;
-    private List<Expression<Func<TEntity, object>>>? _excludeExpressions;
+    private List<Expression<Func<TEntity, object?>>>? _excludeExpressions;
     private Expression<Func<TEntity, TEntity, TEntity>>? _updateExpression;
     private Expression<Func<TEntity, TEntity, bool>>? _updateCondition;
     private bool _allowIdentityMatch;
@@ -67,7 +67,7 @@ public class UpsertCommandBuilder<TEntity> where TEntity : class
     /// </summary>
     /// <param name="exclude">The expression that will identify the columns to exclude</param>
     /// <returns>The current instance of the UpsertCommandBuilder</returns>
-    public UpsertCommandBuilder<TEntity> Exclude(Expression<Func<TEntity, object>> exclude)
+    public UpsertCommandBuilder<TEntity> Exclude(Expression<Func<TEntity, object?>> exclude)
     {
         if (_updateExpression != null)
             throw new InvalidOperationException(Resources.FormatCantCallMethodWhenMethodHasBeenCalledAsTheyAreMutuallyExclusive(nameof(Exclude), nameof(WhenMatched)));
@@ -252,7 +252,7 @@ public class UpsertCommandBuilder<TEntity> where TEntity : class
     private UpsertCommandArgs<TEntity> CreateCommandArgs()
     {
         var matchProperties = _matchExpression != null
-            ? ProcessPropertiesExpression(_entityType, _matchExpression, true)
+            ? ProcessPropertiesExpression(_entityType, _matchExpression!, true)
             : _entityType.GetProperties().Where(p => p.IsKey()).ToArray();
         if (!_allowIdentityMatch && matchProperties.Any(p => p.ValueGenerated != ValueGenerated.Never))
             throw new InvalidMatchColumnsException();
@@ -281,7 +281,7 @@ public class UpsertCommandBuilder<TEntity> where TEntity : class
         };
     }
 
-    private static IProperty[] ProcessPropertiesExpression(IEntityType entityType, Expression<Func<TEntity, object>> propertiesExpression, bool match)
+    private static IProperty[] ProcessPropertiesExpression(IEntityType entityType, Expression<Func<TEntity, object?>> propertiesExpression, bool match)
     {
         static string UnknownPropertiesExceptionMessage(bool match)
             => match


### PR DESCRIPTION
Currently the following code produces nullable warning:
```csharp
public class MyModel
{
      public int Id {get;set;}
      public required string Name {get;set;}
      public string? Description {get;set;}
}

await dbContext.MyModels
     .Upsert(new() { Id = 42, Name = "Answer to Life"  })
     .Exclude(m => m.Description) // Nullable warning here
     .RunAsync();
```

It works perfectly fine if you use ` .Exclude(m => m.Description!)`.

All I did was to change `Expression<Func<TEntity, object>>`  to `Expression<Func<TEntity, object?>>` for Exclude expressions.