### PR TITLE
feat: Add value type Sentinel check

### DIFF
--- a/src/FlexLabs.EntityFrameworkCore.Upsert/Internal/RelationalColumn.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/Internal/RelationalColumn.cs
@@ -28,7 +28,8 @@ internal sealed record RelationalColumn(
             : null;
 
         string? defaultSql = null;
-        if (rawValue == null)
+        var hasConfiguredDefault = Property.GetDefaultValue() != null || Property.GetDefaultValueSql() != null;
+        if (rawValue == null || (hasConfiguredDefault && Equals(rawValue, Property.Sentinel)))
         {
             if (Property.GetDefaultValue() != null)
                 rawValue = Property.GetDefaultValue();

--- a/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/InMemoryUpsertCommandRunner.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/InMemoryUpsertCommandRunner.cs
@@ -63,16 +63,14 @@ public class InMemoryUpsertCommandRunner : UpsertCommandRunnerBase
             {
                 foreach (var prop in typeof(TEntity).GetProperties())
                 {
-                    if (prop.GetValue(match.NewEntity) == null)
+                    var propValue = prop.GetValue(match.NewEntity);
+                    var property = entityType.FindProperty(prop.Name);
+                    if (property != null)
                     {
-                        var property = entityType.FindProperty(prop.Name);
-                        if (property != null)
+                        var defaultValue = property.GetDefaultValue();
+                        if (defaultValue != null && (propValue == null || Equals(propValue, property.Sentinel)))
                         {
-                            var defaultValue = property.GetDefaultValue();
-                            if (defaultValue != null)
-                            {
-                                prop.SetValue(match.NewEntity, defaultValue);
-                            }
+                            prop.SetValue(match.NewEntity, defaultValue);
                         }
                     }
                 }

--- a/test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests/Base/Tables.cs
+++ b/test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests/Base/Tables.cs
@@ -143,6 +143,13 @@ public class TestEntity
     public DateTime Updated { get; set; }
 }
 
+public class SentinelEntity
+{
+    public int ID { get; set; }
+    public int Num1 { get; set; }
+    public int Num2 { get; set; }
+}
+
 public class TestEntityFiltered
 {
     public int ID { get; set; }

--- a/test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests/Base/TestDbContext.cs
+++ b/test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests/Base/TestDbContext.cs
@@ -17,6 +17,8 @@ public class TestDbContext : DbContext
 
         modelBuilder.Entity<TestEntity>().HasIndex(b => b.Num1).IsUnique();
         modelBuilder.Entity<TestEntity>().Property(e => e.Num2).HasDefaultValue(27);
+        modelBuilder.Entity<SentinelEntity>().HasIndex(b => b.Num1).IsUnique();
+        modelBuilder.Entity<SentinelEntity>().Property(e => e.Num2).HasDefaultValue(27).HasSentinel(-1);
         modelBuilder.Entity<TestEntityFiltered>().HasIndex(b => b.Key).IsUnique();
         modelBuilder.Entity<TestEntityFiltered>().HasQueryFilter(b => !b.IsDeleted);
         modelBuilder.Entity<ULongEntity>().HasIndex(b => b.Num1).IsUnique();
@@ -122,6 +124,7 @@ public class TestDbContext : DbContext
     public DbSet<Status> Statuses { get; set; }
     public DbSet<StringKey> StringKeys { get; set; }
     public DbSet<StringKeyAutoGen> StringKeysAutoGen { get; set; }
+    public DbSet<SentinelEntity> SentinelEntities { get; set; }
     public DbSet<TestEntity> TestEntities { get; set; }
     public DbSet<TestEntityFiltered> TestEntitiesFiltered { get; set; }
     public DbSet<ULongEntity> ULongEntities { get; set; }

--- a/test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests/DbTestsBase.cs
+++ b/test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests/DbTestsBase.cs
@@ -103,6 +103,7 @@ public abstract partial class DbTestsBase
         Reset(dbContext, e => e.Statuses);
         Reset(dbContext, e => e.StringKeys);
         Reset(dbContext, e => e.StringKeysAutoGen);
+        Reset(dbContext, e => e.SentinelEntities);
         Reset(dbContext, e => e.TestEntities);
         Reset(dbContext, e => e.TestEntitiesFiltered);
         Reset(dbContext, e => e.ULongEntities);

--- a/test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests/DbTestsBase.cs
+++ b/test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests/DbTestsBase.cs
@@ -2350,6 +2350,90 @@ public abstract partial class DbTestsBase
             r => r.Text.Should().Be("B"));
     }
 
+    [Fact(DisplayName = "Insert with CLR default value (0) should use HasDefaultValue(27)")]
+    public void Upsert_ValueType_DefaultValue_Insert()
+    {
+        ResetDb();
+        using var dbContext = new TestDbContext(_fixture.DataContextOptions);
+
+        var newItem = new TestEntity
+        {
+            Num1 = 1,
+            Num2 = 0,
+            Text1 = "Test",
+            Text2 = "Value",
+        };
+
+        dbContext.TestEntities.Upsert(newItem)
+            .On(j => j.Num1)
+            .Run();
+
+        dbContext.TestEntities.OrderBy(t => t.ID).Should().SatisfyRespectively(
+            test => test.Num2.Should().Be(27));
+    }
+
+    [Fact(DisplayName = "Insert with explicit non-default value (42) should preserve it despite HasDefaultValue(27)")]
+    public void Upsert_ValueType_ExplicitValue_Insert()
+    {
+        ResetDb();
+        using var dbContext = new TestDbContext(_fixture.DataContextOptions);
+
+        var newItem = new TestEntity
+        {
+            Num1 = 1,
+            Num2 = 42,
+            Text1 = "Test",
+            Text2 = "Value",
+        };
+
+        dbContext.TestEntities.Upsert(newItem)
+            .On(j => j.Num1)
+            .Run();
+
+        dbContext.TestEntities.OrderBy(t => t.ID).Should().SatisfyRespectively(
+            test => test.Num2.Should().Be(newItem.Num2));
+    }
+
+    [Fact(DisplayName = "With HasSentinel(-1), inserting Num2=0 should preserve 0 (not sentinel)")]
+    public void Upsert_ValueType_CustomSentinel_Insert()
+    {
+        ResetDb();
+        using var dbContext = new TestDbContext(_fixture.DataContextOptions);
+
+        var newItem = new SentinelEntity
+        {
+            Num1 = 1,
+            Num2 = 0,
+        };
+
+        dbContext.SentinelEntities.Upsert(newItem)
+            .On(j => j.Num1)
+            .Run();
+
+        dbContext.SentinelEntities.OrderBy(t => t.ID).Should().SatisfyRespectively(
+            test => test.Num2.Should().Be(0));
+    }
+
+    [Fact(DisplayName = "With HasSentinel(-1), inserting Num2=-1 should use HasDefaultValue(27)")]
+    public void Upsert_ValueType_CustomSentinel_UsesDefault()
+    {
+        ResetDb();
+        using var dbContext = new TestDbContext(_fixture.DataContextOptions);
+
+        var newItem = new SentinelEntity
+        {
+            Num1 = 1,
+            Num2 = -1,
+        };
+
+        dbContext.SentinelEntities.Upsert(newItem)
+            .On(j => j.Num1)
+            .Run();
+
+        dbContext.SentinelEntities.OrderBy(t => t.ID).Should().SatisfyRespectively(
+            test => test.Num2.Should().Be(27));
+    }
+
     [Fact]
     public void Upsert_100k_Insert_MultiQuery()
     {


### PR DESCRIPTION
**Hello!**
Please, check changes related with fix of this [issue](https://github.com/artiomchi/FlexLabs.Upsert/issues/171)

**Problem:** When performing upsert operations, EF Core's `HasDefaultValue()` and `HasDefaultValueSql()` configurations were ignored for value types (`int`, `bool`, `DateTimeOffset`, etc.).

The root cause was in `RelationalColumn.GetValue()` — the check `if (rawValue == null)` only triggered for `null` values. For value types, the CLR default (`0`, `false`, `default(DateTimeOffset)`) is never `null`, so the configured database default was silently skipped and the CLR default was inserted instead.

The same issue existed in `InMemoryUpsertCommandRunner` for the insert path.

**My Fix suggestion:** Replace the `null` only check with a sentinel-aware comparison using EF Core's `IProperty.Sentinel`. When a property has a configured default and its value equals the sentinel (which defaults to the CLR default for the type), the library now correctly uses the configured default value or default SQL expression.

This also respects custom sentinel values set via `HasSentinel()`, allowing users to distinguish between "value not set" and "intentionally set to the CLR default".

### Breaking change

This changes behavior for properties that have `HasDefaultValue()` configured. Previously, inserting a value equal to the CLR default (e.g. `0` for `int`, `false` for `bool`) would store that CLR default in the database. Now, it will use the configured default value instead.

For example, if a property is configured with `.HasDefaultValue(27)` and you insert an entity with that property set to `0`, the database will now store `27` instead of `0`. This aligns with how EF Core itself handles default values.

If you need to explicitly insert the CLR default value (e.g. `0`) into a column that has a configured default, use `.HasSentinel()` to change the sentinel to a different value:

```csharp
modelBuilder.Entity<MyEntity>()
    .Property(e => e.MyProperty)
    .HasDefaultValue(27)
    .HasSentinel(-1); // now only -1 means "not set", 0 can be inserted explicitly
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved UPSERT insert handling so configured database defaults apply correctly even when EF value sentinels are involved, ensuring consistent behavior for value-type properties.

* **Tests**
  * Added integration test coverage for default-value and sentinel scenarios, including cases that preserve explicit values and cases that correctly fall back to database defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->