### PR TITLE
🔒 Security: Potential SQL injection via unsanitized JSON serialization

### DIFF
--- a/src/FlexLabs.EntityFrameworkCore.Upsert/Internal/JsonColumn.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/Internal/JsonColumn.cs
@@ -24,7 +24,7 @@ internal sealed record JsonColumn(
         // we are now forced to rebuild the serialization logic here in our `RelationalJsonHelper`.
         var jsonValue = RelationalJsonHelper.SerializeToJson(Navigation, rawValue);
 
-        var value = new ConstantValue(jsonValue, this);
+        var value = new ConstantValue(jsonValue, this, isJson: true);
 
         return (ColumnName, value, DefaultSql: null, AllowInserts: true);
     }


### PR DESCRIPTION
## Problem

The `RelationalJsonHelper.SerializeToJson` method is called with raw entity values from user input.
If this method doesn't properly escape JSON content or if there's a vulnerability in the JSON serialization
that could allow SQL injection through JSON string values, user-controlled data could potentially
be injected into SQL queries. Since this library generates SQL commands for upsert operations,
improper handling of JSON values could lead to SQL injection vulnerabilities.

The risk is medium because:
1. The library generates SQL queries with user-provided data
2. JSON values are directly embedded in SQL statements
3. The serialization logic is custom (`RelationalJsonHelper`) and may not properly escape all dangerous characters
4. This affects all database providers that support JSON columns


**Severity**: `medium`
**File**: `src/FlexLabs.EntityFrameworkCore.Upsert/Internal/JsonColumn.cs`

## Solution

Ensure `RelationalJsonHelper.SerializeToJson` properly escapes JSON strings and validates the structure.
Consider using parameterized queries for JSON values instead of embedding them directly in SQL.
Add unit tests that verify SQL injection attempts are properly escaped.


## Changes

- `src/FlexLabs.EntityFrameworkCore.Upsert/Internal/JsonColumn.cs` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
