### PR TITLE
Use IsProvider() extension methods instead of hardcoded provider names

### DIFF
--- a/test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests/Base/TestDbContext.cs
+++ b/test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests/Base/TestDbContext.cs
@@ -1,5 +1,3 @@
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Storage;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -13,8 +11,6 @@ public class TestDbContext : DbContext
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        var dbProvider = this.GetService<IDatabaseProvider>();
-
         modelBuilder.Entity<TestEntity>().HasIndex(b => b.Num1).IsUnique();
         modelBuilder.Entity<TestEntity>().Property(e => e.Num2).HasDefaultValue(27);
         modelBuilder.Entity<TestEntityFiltered>().HasIndex(b => b.Key).IsUnique();
@@ -39,14 +35,14 @@ public class TestDbContext : DbContext
         modelBuilder.Entity<GeneratedAlwaysAsIdentity>().Property(e => e.Num2).UseIdentityAlwaysColumn();
         modelBuilder.Entity<ComputedColumn>().HasIndex(b => b.Num1).IsUnique();
         modelBuilder.Entity<ComputedColumn>().Property(e => e.Num3)
-            .HasComputedColumnSql($"{EscapeColumn(dbProvider, nameof(ComputedColumn.Num2))} + 1", stored: true);
+            .HasComputedColumnSql($"{EscapeColumn(nameof(ComputedColumn.Num2))} + 1", stored: true);
 
         modelBuilder.Entity<Parent>()
             .OwnsOne(
                 c => c.Child,
                 b => { b.OwnsOne(c => c.SubChild); });
 
-        if (dbProvider.Name == "Npgsql.EntityFrameworkCore.PostgreSQL")
+        if (Database.IsNpgsql())
         {
             modelBuilder.Entity<JsonData>().Property(j => j.Data).HasColumnType("jsonb");
             modelBuilder.Entity<JsonData>().Property(j => j.Child).HasColumnType("jsonb");
@@ -67,7 +63,7 @@ public class TestDbContext : DbContext
                     b.OwnsMany(c => c.Properties);
                 });
 
-        if (dbProvider.Name == "Microsoft.EntityFrameworkCore.InMemory")
+        if (Database.IsInMemory())
         {
             // in-memory provider does not support complex properties
             modelBuilder.Entity<ParentComplex>().Ignore(c => c.Child);
@@ -84,27 +80,39 @@ public class TestDbContext : DbContext
                 .ComplexProperty(j => j.Meta, b => b.ToJson());
         }
 
-        if (dbProvider.Name != "Pomelo.EntityFrameworkCore.MySql") // Can't have a default value on TEXT columns in MySql
+        if (!DatabaseIsMySql()) // Can't have a default value on TEXT columns in MySql
         {
             modelBuilder.Entity<NullableRequired>().Property(e => e.Text).HasDefaultValue("B");
         }
 
-        if (dbProvider.Name != "Pomelo.EntityFrameworkCore.MySql" &&
-            dbProvider.Name != "Oracle.EntityFrameworkCore") // Can't have table schemas in MySql and Oracle
+        if (!DatabaseIsMySql() && !Database.IsOracle()) // Can't have table schemas in MySql and Oracle
         {
             modelBuilder.Entity<SchemaTable>().Metadata.SetSchema("testsch");
         }
     }
 
-    private string EscapeColumn(IDatabaseProvider dbProvider, string columnName)
-        => dbProvider.Name switch
+    private string EscapeColumn(string columnName)
+    {
+        if (Database.IsSqlServer())
         {
-            "Pomelo.EntityFrameworkCore.MySql" => $"`{columnName}`",
-            "Npgsql.EntityFrameworkCore.PostgreSQL" => $"\"{columnName}\"",
-            "Microsoft.EntityFrameworkCore.Sqlite" => $"\"{columnName}\"",
-            "Oracle.EntityFrameworkCore" => columnName.ToUpper(),
-            _ => $"[{columnName}]"
-        };
+            return $"[{columnName}]";
+        }
+        if (DatabaseIsMySql())
+        {
+            return $"`{columnName}`";
+        }
+        if (Database.IsOracle())
+        {
+            return columnName.ToUpper();
+        }
+        return $"\"{columnName}\"";
+    }
+
+#if NOMYSQL
+    private static bool DatabaseIsMySql() => false;
+#else
+    private bool DatabaseIsMySql => Database.IsMySql();
+#endif
 
     public DbSet<Book> Books { get; set; }
     public DbSet<Country> Countries { get; set; }

--- a/test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests.csproj
+++ b/test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
-    <!-- <PackageReference Include="Oracle.EntityFrameworkCore" /> -->
+    <PackageReference Include="Oracle.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="NSubstitute" />


### PR DESCRIPTION
This will prove useful when switching from Pomelo.EntityFrameworkCore.MySql to Microting.EntityFrameworkCore.MySql

This is also a little bit more readable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test database configuration to use provider-specific detection methods for more reliable, accurate provider handling across test runs.
* **Chores**
  * Activated Oracle EF Core package in the test project to ensure Oracle provider tests run as part of the test suite.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/artiomchi/FlexLabs.Upsert/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->