### PR TITLE
Enable MySQL integration tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,8 +27,8 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.*" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.*" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.*" />
+    <PackageVersion Include="Microting.EntityFrameworkCore.MySql" Version="10.0.*" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.*" />
     <PackageVersion Include="Oracle.EntityFrameworkCore" Version="10.*" />
-    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="9.*" />
   </ItemGroup>
 </Project>

--- a/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/MySqlUpsertCommandRunner.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/MySqlUpsertCommandRunner.cs
@@ -10,10 +10,12 @@ namespace FlexLabs.EntityFrameworkCore.Upsert.Runners;
 public class MySqlUpsertCommandRunner : RelationalUpsertCommandRunner
 {
     /// <inheritdoc/>
-    public override bool Supports(string providerName) =>
-        providerName == "MySql.Data.EntityFrameworkCore" ||
-        providerName == "MySql.EntityFrameworkCore" ||
-        providerName == "Pomelo.EntityFrameworkCore.MySql";
+    public override bool Supports(string providerName)
+    {
+        ArgumentNullException.ThrowIfNull(providerName);
+        return providerName.Contains("MySql", StringComparison.OrdinalIgnoreCase);
+    }
+
     /// <inheritdoc/>
     protected override string EscapeName(string name) => "`" + name + "`";
     /// <inheritdoc/>

--- a/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/MySqlUpsertCommandRunner.cs
+++ b/src/FlexLabs.EntityFrameworkCore.Upsert/Runners/MySqlUpsertCommandRunner.cs
@@ -5,7 +5,9 @@ using FlexLabs.EntityFrameworkCore.Upsert.Internal.Expressions;
 namespace FlexLabs.EntityFrameworkCore.Upsert.Runners;
 
 /// <summary>
-/// Upsert command runner for the MySql.Data.EntityFrameworkCore or the Pomelo.EntityFrameworkCore.MySql providers
+/// Upsert command runner for MySQL providers.
+/// <para/>
+/// This includes <c>Microting.EntityFrameworkCore.MySql</c>, <c>MySql.EntityFrameworkCore</c> and <c>Pomelo.EntityFrameworkCore.MySql</c> or any other provider that contains <c>MySql</c> in their name.
 /// </summary>
 public class MySqlUpsertCommandRunner : RelationalUpsertCommandRunner
 {

--- a/test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests/Base/TestDbContext.cs
+++ b/test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests/Base/TestDbContext.cs
@@ -80,12 +80,12 @@ public class TestDbContext : DbContext
                 .ComplexProperty(j => j.Meta, b => b.ToJson());
         }
 
-        if (!DatabaseIsMySql()) // Can't have a default value on TEXT columns in MySql
+        if (!Database.IsMySql()) // Can't have a default value on TEXT columns in MySql
         {
             modelBuilder.Entity<NullableRequired>().Property(e => e.Text).HasDefaultValue("B");
         }
 
-        if (!DatabaseIsMySql() && !Database.IsOracle()) // Can't have table schemas in MySql and Oracle
+        if (!Database.IsMySql() && !Database.IsOracle()) // Can't have table schemas in MySql and Oracle
         {
             modelBuilder.Entity<SchemaTable>().Metadata.SetSchema("testsch");
         }
@@ -97,7 +97,7 @@ public class TestDbContext : DbContext
         {
             return $"[{columnName}]";
         }
-        if (DatabaseIsMySql())
+        if (Database.IsMySql())
         {
             return $"`{columnName}`";
         }
@@ -107,12 +107,6 @@ public class TestDbContext : DbContext
         }
         return $"\"{columnName}\"";
     }
-
-#if NOMYSQL
-    private static bool DatabaseIsMySql() => false;
-#else
-    private bool DatabaseIsMySql => Database.IsMySql();
-#endif
 
     public DbSet<Book> Books { get; set; }
     public DbSet<Country> Countries { get; set; }

--- a/test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests.csproj
+++ b/test/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests/FlexLabs.EntityFrameworkCore.Upsert.IntegrationTests.csproj
@@ -18,8 +18,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!--Disabling MySQL tests until they have a stable and working version-->
-    <DefineConstants>$(DefineConstants);NOMYSQL;NOORACLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);NOORACLE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -31,10 +30,10 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="Oracle.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microting.EntityFrameworkCore.MySql" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" PrivateAssets="all" />
-    <!-- <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" /> -->
     <PackageReference Include="Testcontainers.MsSql" />
     <PackageReference Include="Testcontainers.MySql" />
     <PackageReference Include="Testcontainers.PostgreSql" />


### PR DESCRIPTION
Thanks to the Microting fork (Microting.EntityFrameworkCore.MySql)

It seems like Pomelo.EntityFrameworkCore.MySql for EF Core 10 might never happen. See https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/2007 and https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/pull/2019

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Dependencies**
  * Updated the MySQL Entity Framework Core database provider to Microting (version 10.0.*).

* **Refactor**
  * Improved database provider detection to support MySQL when the provider name contains “MySql” (case-insensitive).
  * Simplified integration test database setup to use direct MySQL checks and removed compile-time overrides.

* **Tests**
  * Adjusted the `POSTGRES_ONLY` build behaviour to disable Oracle (rather than MySQL).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->